### PR TITLE
Add LVGL 9 MatrixRain canvas animation (Matrix digital rain)

### DIFF
--- a/LVGL/MatrixRain/MatrixRain.cpp
+++ b/LVGL/MatrixRain/MatrixRain.cpp
@@ -1,0 +1,292 @@
+#include "MatrixRain.hpp"
+
+#include <algorithm>
+#include <chrono>
+
+namespace {
+lv_color_t backgroundColor() { return lv_color_hex(0x000000); }
+lv_color_t matrixGreen() { return lv_color_hex(0x00ff41); }
+lv_color_t headRed() { return lv_color_hex(0xff2020); }
+
+bool timeReached(uint32_t now_ms, uint32_t target_ms)
+{
+    return static_cast<int32_t>(now_ms - target_ms) >= 0;
+}
+
+uint32_t makeSeed()
+{
+    const auto now = std::chrono::steady_clock::now().time_since_epoch().count();
+    return static_cast<uint32_t>(now ^ reinterpret_cast<uintptr_t>(&now));
+}
+} // namespace
+
+MatrixRain::MatrixRain(lv_obj_t * panel)
+    : MatrixRain(panel, Config{})
+{
+}
+
+MatrixRain::MatrixRain(lv_obj_t * panel, Config config)
+    : panel_(panel), config_(config), rng_(makeSeed())
+{
+    if(panel_ == nullptr) return;
+
+    config_.cell_width = std::max<uint16_t>(1, config_.cell_width);
+    config_.cell_height = std::max<uint16_t>(1, config_.cell_height);
+    config_.trail_length = std::max<uint16_t>(1, config_.trail_length);
+    config_.spawn_max_period_ms = std::max(config_.spawn_min_period_ms, config_.spawn_max_period_ms);
+
+    setupPanel();
+    render();
+    scheduleNextSpawn(lv_tick_get());
+    timer_ = lv_timer_create(MatrixRain::timerThunk, config_.timer_period_ms, this);
+}
+
+MatrixRain::~MatrixRain()
+{
+    if(timer_ != nullptr) {
+        lv_timer_delete(timer_);
+        timer_ = nullptr;
+    }
+
+    if(panel_ != nullptr) {
+        lv_obj_clean(panel_);
+        if(config_.delete_panel_on_destroy) {
+            lv_obj_delete(panel_);
+        }
+    }
+
+    canvas_ = nullptr;
+    panel_ = nullptr;
+}
+
+uint8_t MatrixRain::newCol(uint8_t n)
+{
+    uint8_t created = 0;
+    const uint32_t now = lv_tick_get();
+    for(uint8_t i = 0; i < n; ++i) {
+        if(spawnColumn(true, now)) ++created;
+    }
+    if(created > 0) render();
+    return created;
+}
+
+void MatrixRain::setFallPeriod(uint32_t period_ms)
+{
+    config_.fall_period_ms = std::max<uint32_t>(1, period_ms);
+}
+
+void MatrixRain::setTrailLength(uint16_t length)
+{
+    config_.trail_length = std::max<uint16_t>(1, length);
+    for(auto & column : columns_) {
+        if(column.digits.size() > config_.trail_length) column.digits.resize(config_.trail_length);
+    }
+}
+
+void MatrixRain::setMaxActiveColumns(uint16_t count)
+{
+    config_.max_active_columns = count;
+}
+
+void MatrixRain::timerThunk(lv_timer_t * timer)
+{
+    auto * self = static_cast<MatrixRain *>(lv_timer_get_user_data(timer));
+    if(self != nullptr) self->tick();
+}
+
+void MatrixRain::setupPanel()
+{
+    lv_obj_update_layout(panel_);
+    width_ = lv_obj_get_content_width(panel_);
+    height_ = lv_obj_get_content_height(panel_);
+    if(width_ <= 0) width_ = lv_obj_get_width(panel_);
+    if(height_ <= 0) height_ = lv_obj_get_height(panel_);
+    if(width_ <= 0 || height_ <= 0) return;
+
+    slot_count_ = static_cast<uint16_t>(std::max<lv_coord_t>(1, width_ / config_.cell_width));
+    row_count_ = static_cast<uint16_t>(std::max<lv_coord_t>(1, (height_ + config_.cell_height - 1) / config_.cell_height));
+    occupied_slots_.assign(slot_count_, false);
+    columns_.reserve(activeLimit());
+
+    lv_obj_clean(panel_);
+    lv_obj_set_style_bg_color(panel_, backgroundColor(), 0);
+    lv_obj_set_style_bg_opa(panel_, LV_OPA_COVER, 0);
+    lv_obj_clear_flag(panel_, LV_OBJ_FLAG_SCROLLABLE);
+
+    canvas_buffer_.assign(static_cast<size_t>(width_) * static_cast<size_t>(height_) * 4U, 0);
+    canvas_ = lv_canvas_create(panel_);
+    lv_obj_set_size(canvas_, width_, height_);
+    lv_obj_align(canvas_, LV_ALIGN_TOP_LEFT, 0, 0);
+    lv_canvas_set_buffer(canvas_, canvas_buffer_.data(), width_, height_, LV_COLOR_FORMAT_ARGB8888);
+    lv_canvas_fill_bg(canvas_, backgroundColor(), LV_OPA_COVER);
+}
+
+void MatrixRain::tick()
+{
+    if(canvas_ == nullptr) return;
+
+    const uint32_t now = lv_tick_get();
+    const size_t before = columns_.size();
+    stepColumns(now);
+    tryAutoSpawn(now);
+
+    if(before != columns_.size() || !columns_.empty()) {
+        render();
+    }
+}
+
+void MatrixRain::stepColumns(uint32_t now_ms)
+{
+    bool any_changed = false;
+    for(size_t i = 0; i < columns_.size();) {
+        DropColumn & column = columns_[i];
+        if(timeReached(now_ms, column.next_step_ms)) {
+            if(column.head_row >= 0) {
+                column.digits.insert(column.digits.begin(), column.lead_digit);
+                if(column.digits.size() > 1) {
+                    column.digits[1] = randomDigitExcept(column.lead_digit);
+                }
+                if(column.digits.size() > config_.trail_length) column.digits.resize(config_.trail_length);
+            }
+
+            ++column.head_row;
+            column.next_step_ms = now_ms + config_.fall_period_ms;
+            any_changed = true;
+        }
+
+        const int16_t oldest_row = static_cast<int16_t>(column.head_row - static_cast<int16_t>(column.digits.size()) + 1);
+        if(oldest_row >= static_cast<int16_t>(row_count_)) {
+            retireColumn(i);
+            any_changed = true;
+        } else {
+            ++i;
+        }
+    }
+
+    (void)any_changed;
+}
+
+void MatrixRain::scheduleNextSpawn(uint32_t now_ms)
+{
+    next_spawn_ms_ = now_ms + randomRange(config_.spawn_min_period_ms, config_.spawn_max_period_ms);
+}
+
+void MatrixRain::tryAutoSpawn(uint32_t now_ms)
+{
+    if(columns_.size() >= activeLimit()) return;
+    if(!timeReached(now_ms, next_spawn_ms_)) return;
+
+    const bool special = randomPercent() < config_.special_chance_percent;
+    spawnColumn(special, now_ms);
+    scheduleNextSpawn(now_ms);
+}
+
+bool MatrixRain::spawnColumn(bool special, uint32_t now_ms)
+{
+    if(canvas_ == nullptr) return false;
+    if(columns_.size() >= activeLimit()) return false;
+    if(slot_count_ == 0) return false;
+
+    const uint16_t slot = randomFreeSlot();
+    if(slot >= slot_count_) return false;
+
+    DropColumn column;
+    column.slot = slot;
+    column.head_row = -1;
+    column.lead_digit = randomDigit();
+    column.special = special;
+    column.next_step_ms = now_ms + randomRange(0, config_.fall_period_ms);
+    column.digits.push_back(column.lead_digit);
+
+    occupied_slots_[slot] = true;
+    columns_.push_back(std::move(column));
+    return true;
+}
+
+void MatrixRain::retireColumn(size_t index)
+{
+    if(index >= columns_.size()) return;
+    const uint16_t slot = columns_[index].slot;
+    if(slot < occupied_slots_.size()) occupied_slots_[slot] = false;
+    columns_.erase(columns_.begin() + static_cast<std::ptrdiff_t>(index));
+}
+
+void MatrixRain::render()
+{
+    if(canvas_ == nullptr) return;
+
+    lv_canvas_fill_bg(canvas_, backgroundColor(), LV_OPA_COVER);
+
+    lv_layer_t layer;
+    lv_canvas_init_layer(canvas_, &layer);
+
+    for(const auto & column : columns_) {
+        const lv_coord_t x = static_cast<lv_coord_t>(column.slot * config_.cell_width);
+        for(size_t offset = 0; offset < column.digits.size(); ++offset) {
+            const int16_t row = static_cast<int16_t>(column.head_row - static_cast<int16_t>(offset));
+            if(row < 0 || row >= static_cast<int16_t>(row_count_)) continue;
+
+            const lv_coord_t y = static_cast<lv_coord_t>(row * config_.cell_height);
+            const uint8_t digit = (offset == 0) ? column.lead_digit : column.digits[offset];
+            const char text[] = {static_cast<char>('0' + digit), '\0'};
+
+            lv_draw_label_dsc_t label_dsc;
+            lv_draw_label_dsc_init(&label_dsc);
+            label_dsc.text = text;
+            label_dsc.font = config_.font;
+            label_dsc.color = (offset == 0 && column.special) ? headRed() : matrixGreen();
+
+            const uint16_t denominator = std::max<uint16_t>(1, config_.trail_length - 1);
+            const int32_t fade = static_cast<int32_t>(LV_OPA_COVER - config_.min_trail_opa) * static_cast<int32_t>(offset) / denominator;
+            label_dsc.opa = static_cast<lv_opa_t>(std::max<int32_t>(config_.min_trail_opa, LV_OPA_COVER - fade));
+
+            lv_area_t coords = {x, y, static_cast<lv_coord_t>(x + config_.cell_width - 1), static_cast<lv_coord_t>(y + config_.cell_height - 1)};
+            lv_draw_label(&layer, &label_dsc, &coords);
+        }
+    }
+
+    lv_canvas_finish_layer(canvas_, &layer);
+    lv_obj_invalidate(canvas_);
+}
+
+uint8_t MatrixRain::randomDigit()
+{
+    return static_cast<uint8_t>(randomRange(0, 9));
+}
+
+uint8_t MatrixRain::randomDigitExcept(uint8_t value)
+{
+    uint8_t digit = randomDigit();
+    if(digit == value) digit = static_cast<uint8_t>((digit + 1U + randomRange(0, 8)) % 10U);
+    return digit;
+}
+
+uint16_t MatrixRain::randomFreeSlot()
+{
+    std::vector<uint16_t> free_slots;
+    free_slots.reserve(slot_count_);
+    for(uint16_t slot = 0; slot < slot_count_; ++slot) {
+        if(!occupied_slots_[slot]) free_slots.push_back(slot);
+    }
+    if(free_slots.empty()) return slot_count_;
+    return free_slots[randomRange(0, static_cast<uint32_t>(free_slots.size() - 1))];
+}
+
+uint8_t MatrixRain::randomPercent()
+{
+    return static_cast<uint8_t>(randomRange(0, 99));
+}
+
+uint32_t MatrixRain::randomRange(uint32_t min_value, uint32_t max_value)
+{
+    if(max_value <= min_value) return min_value;
+    std::uniform_int_distribution<uint32_t> distribution(min_value, max_value);
+    return distribution(rng_);
+}
+
+uint16_t MatrixRain::activeLimit() const
+{
+    if(slot_count_ == 0) return 0;
+    if(config_.max_active_columns == 0) return slot_count_;
+    return std::min<uint16_t>(slot_count_, config_.max_active_columns);
+}

--- a/LVGL/MatrixRain/MatrixRain.hpp
+++ b/LVGL/MatrixRain/MatrixRain.hpp
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <cstdint>
+#include <random>
+#include <vector>
+
+#include "lvgl.h"
+
+/**
+ * Canvas based Matrix-style digital rain for LVGL 9.
+ *
+ * MatrixRain owns only the canvas, timer and pixel buffer it creates. The input
+ * panel is treated as an external container by default; set
+ * Config::delete_panel_on_destroy if the MatrixRain instance should delete it.
+ */
+class MatrixRain {
+public:
+    struct Config {
+        uint16_t cell_width = 16;              ///< Pixel width of one digit cell.
+        uint16_t cell_height = 22;             ///< Pixel height of one digit cell.
+        uint16_t max_active_columns = 18;      ///< Maximum simultaneously falling columns.
+        uint16_t trail_length = 12;            ///< Number of visible cells behind the head.
+        uint32_t fall_period_ms = 85;          ///< Time for a column to move down one cell.
+        uint32_t timer_period_ms = 25;         ///< LVGL timer tick used to drive animation.
+        uint32_t spawn_min_period_ms = 450;    ///< Minimum delay between automatic spawns.
+        uint32_t spawn_max_period_ms = 1500;   ///< Maximum delay between automatic spawns.
+        uint8_t special_chance_percent = 8;    ///< Automatic red-head spawn chance.
+        uint8_t min_trail_opa = 35;            ///< Opacity at the oldest tail cell.
+        const lv_font_t * font = LV_FONT_DEFAULT;
+        bool delete_panel_on_destroy = false;  ///< Also delete the caller-provided panel.
+    };
+
+    explicit MatrixRain(lv_obj_t * panel);
+    MatrixRain(lv_obj_t * panel, Config config);
+    ~MatrixRain();
+
+    MatrixRain(const MatrixRain &) = delete;
+    MatrixRain & operator=(const MatrixRain &) = delete;
+
+    /**
+     * Immediately creates up to n special columns. A special column has a red
+     * leading digit; the rest of its trail uses Matrix green.
+     */
+    uint8_t newCol(uint8_t n);
+
+    void setFallPeriod(uint32_t period_ms);
+    void setTrailLength(uint16_t length);
+    void setMaxActiveColumns(uint16_t count);
+
+private:
+    struct DropColumn {
+        uint16_t slot = 0;
+        int16_t head_row = -1;
+        uint8_t lead_digit = 0;
+        bool special = false;
+        uint32_t next_step_ms = 0;
+        std::vector<uint8_t> digits;
+    };
+
+    static void timerThunk(lv_timer_t * timer);
+
+    void setupPanel();
+    void tick();
+    void stepColumns(uint32_t now_ms);
+    void scheduleNextSpawn(uint32_t now_ms);
+    void tryAutoSpawn(uint32_t now_ms);
+    bool spawnColumn(bool special, uint32_t now_ms);
+    void retireColumn(size_t index);
+    void render();
+
+    uint8_t randomDigit();
+    uint8_t randomDigitExcept(uint8_t value);
+    uint16_t randomFreeSlot();
+    uint8_t randomPercent();
+    uint32_t randomRange(uint32_t min_value, uint32_t max_value);
+    uint16_t activeLimit() const;
+
+    lv_obj_t * panel_ = nullptr;
+    lv_obj_t * canvas_ = nullptr;
+    lv_timer_t * timer_ = nullptr;
+    Config config_;
+
+    lv_coord_t width_ = 0;
+    lv_coord_t height_ = 0;
+    uint16_t slot_count_ = 0;
+    uint16_t row_count_ = 0;
+    uint32_t next_spawn_ms_ = 0;
+
+    std::vector<uint8_t> canvas_buffer_;
+    std::vector<bool> occupied_slots_;
+    std::vector<DropColumn> columns_;
+
+    std::mt19937 rng_;
+};

--- a/LVGL/MatrixRain/README.md
+++ b/LVGL/MatrixRain/README.md
@@ -1,0 +1,34 @@
+# LVGL 9 MatrixRain
+
+`MatrixRain` is a C++ LVGL 9 canvas animation that renders a Matrix-style digital rain effect.
+
+## Files
+
+- `MatrixRain.hpp` / `MatrixRain.cpp`: reusable class implementation.
+- `example.cpp`: minimal usage example.
+
+## Behavior
+
+- Uses one `lv_canvas` over a caller-provided `panel` for better performance than many labels.
+- Clears the panel to black and draws green falling digits.
+- Each column moves down one grid cell at a time.
+- When the head leaves a cell, that old cell is replaced by a random fixed digit and then fades as the trail ages.
+- The leading digit keeps its original number for the life of the column.
+- Special columns draw the leading digit in red; call `newCol(n)` to create up to `n` special columns immediately.
+- Automatic columns use random non-overlapping slots and randomized spawn delays to avoid bursty drops.
+
+## Basic usage
+
+```cpp
+#include "MatrixRain.hpp"
+
+MatrixRain::Config config;
+config.fall_period_ms = 80;
+config.trail_length = 14;
+config.max_active_columns = 20;
+
+MatrixRain rain(panel, config);
+rain.newCol(1); // one immediate red-head column
+```
+
+Destroying `MatrixRain` deletes its timer, clears the panel children and releases the canvas buffer. By default it does not delete the caller-owned `panel`; set `Config::delete_panel_on_destroy = true` only if the `MatrixRain` object owns that panel.

--- a/LVGL/MatrixRain/example.cpp
+++ b/LVGL/MatrixRain/example.cpp
@@ -1,0 +1,33 @@
+#include "MatrixRain.hpp"
+
+#include <memory>
+
+static std::unique_ptr<MatrixRain> g_matrix_rain;
+
+void create_matrix_rain_demo(lv_obj_t * parent)
+{
+    lv_obj_t * panel = lv_obj_create(parent);
+    lv_obj_remove_style_all(panel);
+    lv_obj_set_size(panel, lv_pct(100), lv_pct(100));
+    lv_obj_center(panel);
+
+    MatrixRain::Config config;
+    config.cell_width = 14;
+    config.cell_height = 20;
+    config.trail_length = 14;
+    config.max_active_columns = 20;
+    config.fall_period_ms = 80;
+    config.spawn_min_period_ms = 500;
+    config.spawn_max_period_ms = 1600;
+    config.special_chance_percent = 10;
+
+    g_matrix_rain = std::make_unique<MatrixRain>(panel, config);
+
+    // Create two red-head columns immediately, for example after entering a mode.
+    g_matrix_rain->newCol(2);
+}
+
+void destroy_matrix_rain_demo()
+{
+    g_matrix_rain.reset();
+}


### PR DESCRIPTION
### Motivation

- Provide a reusable C++ `MatrixRain` component that renders a Matrix-style digital rain using LVGL 9 and a single canvas for better performance. 
- Support configurable visual behavior (speed, trail length, column count) and a special mode where the leading digit is red while trails are green and fade.
- Ensure columns spawn at randomized, non-overlapping slots with randomized start times to avoid bursty drops and meet the requested visual rules.

### Description

- Add `LVGL/MatrixRain/MatrixRain.hpp` and `LVGL/MatrixRain/MatrixRain.cpp` implementing the `MatrixRain` class which owns an ARGB8888 canvas buffer, an LVGL timer, RNG, and column state structures (`DropColumn`).
- Rendering uses a single `lv_canvas` and LVGL draw APIs (`lv_canvas_init_layer`, `lv_draw_label`, opacity calculation) to draw digits, compute fade per trail cell, and draw special red heads versus green trails.
- Column spawn logic guarantees non-overlapping slots via `occupied_slots_`, randomized spawn delays and per-column random offsets, and `newCol(uint8_t n)` to immediately create up to `n` special (red-head) columns.
- Add `example.cpp` demonstrating usage and a `README.md` documenting behavior, config options, and basic usage; the destructor removes the timer and clears (optionally deletes) the provided panel.

### Testing

- Performed a syntax-only compile check with a lightweight LVGL stub: `g++ -std=c++17 -fsyntax-only -I/tmp/lvgl_matrixrain_stub LVGL/MatrixRain/MatrixRain.cpp LVGL/MatrixRain/example.cpp` which succeeded.
- Ran `git diff --cached --check` as a repository consistency check which passed, and created a commit containing the four new files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03ea447f7483269f1efb2c85faa08c)